### PR TITLE
Initial weather service

### DIFF
--- a/app/services/weather_service.rb
+++ b/app/services/weather_service.rb
@@ -1,0 +1,10 @@
+class WeatherService
+  def self.location_search(location)
+    conn = Faraday.new("http://dataservice.accuweather.com") do |faraday|
+      faraday.params["q"] = location
+      faraday.params["apikey"] = ENV['weather_api_key']
+    end
+    response = conn.get("/locations/v1/cities/search/")
+    JSON.parse(response.body, symbolize_names: true)
+  end
+end

--- a/spec/services/weather_service_spec.rb
+++ b/spec/services/weather_service_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe WeatherService do
+  describe '::location_search' do
+    it 'returns the location data based on a string search' do
+      data = WeatherService.location_search("Denver")
+      require 'pry'; binding.pry
+    end
+  end
+end

--- a/spec/services/weather_service_spec.rb
+++ b/spec/services/weather_service_spec.rb
@@ -3,8 +3,19 @@ require 'rails_helper'
 RSpec.describe WeatherService do
   describe '::location_search' do
     it 'returns the location data based on a string search' do
-      data = WeatherService.location_search("Denver")
-      require 'pry'; binding.pry
+      data = WeatherService.location_search("80121")
+
+      expect(data[0]).to have_key(:GeoPosition)
+      expect(data[0][:GeoPosition]).to be_a Hash
+
+      expect(data[0][:GeoPosition]).to have_key(:Latitude)
+      expect(data[0][:GeoPosition][:Latitude]).to be_a Float
+
+      expect(data[0][:GeoPosition]).to have_key(:Longitude)
+      expect(data[0][:GeoPosition][:Longitude]).to be_a Float
+
+      expect(data[0]).to have_key(:EnglishName)
+      expect(data[0][:EnglishName]).to be_a String
     end
   end
 end


### PR DESCRIPTION
This PR Includes: 

- Set up of a basic weather service with one endpoint being consumed in order to retrieve the latitude and longitude for a location.  This is needed in order to later retrieve frost dates based on latitude and longitude in addition to some other weather features.

-[x] 100% RSpec coverage